### PR TITLE
Add TIP-0006: Agent proposal evaluation specification

### DIFF
--- a/TIP-0006.md
+++ b/TIP-0006.md
@@ -1,0 +1,103 @@
+---
+tip: 6
+title: Agent Proposal Evaluation Specification
+author: hummusonrails
+status: Draft
+type: Standards Track
+created: 2025-08-01
+---
+
+## Abstract
+
+This TIP standardizes the interface and output structure of Talos’s proposal evaluation system. Talos uses LLMs to provide recommendations on governance proposals. As its use expands across multiple protocols, consistent input formatting and output schema are required to ensure transparency, auditability, and comparability. This specification defines the expected structure of proposals submitted for evaluation and the output format of Talos’s responses, including risk scoring, precedent analysis, and community alignment metrics.
+
+## Motivation
+
+Talos will increasingly be used as a decision-support agent for protocol governance. As protocols begin to delegate proposal evaluations to Talos, the need arises for a shared standard across:
+
+- The **input structure** of proposals (e.g., what metadata is required, what context should be included)
+- The **output schema** of Talos’s evaluations (e.g., structured fields like `risk_score`, `recommendation`, `precedent_matches`)
+- The **evaluation criteria** to ensure consistency, reproducibility, and transparency
+
+Without this standardization, different instances may operate on incompatible or opaque formats, making it difficult for governance participants to trust or compare the outputs.
+
+## Specification
+
+### 1. Input Proposal Format
+
+Proposals submitted to Talos for evaluation MUST follow this canonical JSON format:
+
+```json
+{
+  "proposal_id": "string",
+  "title": "string",
+  "description": "string",
+  "proposed_by": "address | handle",
+  "timestamp": "RFC3339 datetime string",
+  "actions": [
+    {
+      "type": "enum [parameter_change | contract_upgrade | grant | signaling]",
+      "description": "string",
+      "details": "freeform string or JSON payload"
+    }
+  ],
+  "discussion_link": "url",
+  "context": "optional string with additional protocol metadata or recent changes"
+}
+```
+
+### 2. Evaluation Output Schema
+
+Talos evaluations MUST return the following structured response (in JSON):
+
+```json
+{
+  "proposal_id": "string",
+  "summary": "string",
+  "recommendation": "enum [approve | reject | needs_revision]",
+  "rationale": "string",
+  "risk_score": "float (0.0 to 1.0)",
+  "precedent_matches": [
+    {
+      "past_proposal_id": "string",
+      "similarity_score": "float (0.0 to 1.0)",
+      "outcome": "enum [approved | rejected | unknown]"
+    }
+  ],
+  "community_alignment": "string (optional)",
+  "evaluation_timestamp": "RFC3339 datetime string",
+  "evaluator_version": "string (e.g., talos@0.1.2)"
+}
+```
+
+### 3. Evaluation Criteria
+
+Talos MUST consider the following dimensions during evaluation:
+
+- Protocol Alignment: Does the proposal align with protocol mission and prior decisions?
+- Security Risks: Could the proposed action introduce smart contract vulnerabilities, centralization risks, or governance capture?
+- Economic Impact: Are incentives aligned and sustainable?
+- Precedent: Are there similar past proposals Talos has seen? What were the outcomes?
+- Community Sentiment (if accessible): Are there public signals (e.g., via Twitter or forum sentiment) suggesting support or concern?
+
+Implementations MAY use any underlying model or prompt strategy, but the surface structure must conform to the output schema above.
+
+## Rationale
+
+As LLM-based governance agents like Talos become more autonomous, having well-structured and explainable decision-making outputs is critical. By enforcing a standardized format, we ensure:
+
+- Interoperability across chains and protocols
+- Easier comparison of Talos recommendations to human decisions
+- Stronger ability to benchmark Talos’s accuracy or bias over time
+
+It also supports potential downstream use cases like automated dashboards, voting bots that rely on Talos outputs, or protocol-specific agent forks.
+
+## Security Considerations
+
+- Prompt Injection: If proposal content is not sanitized, prompt injection attacks could alter Talos outputs. Agents MUST implement prompt hygiene measures.
+- Model Drift: Over time, underlying model behavior may change. Including evaluator_version in outputs mitigates this risk by allowing tracking.
+- Over-Reliance: This standard structures decision support, not final decisions. Communities and delegate systems SHOULD NOT blindly follow agent recommendations.
+
+## Copyright Waiver
+
+This TIP is in the public domain. You may freely use, modify, and distribute it.


### PR DESCRIPTION
This PR introduces TIP-0006: Agent Proposal Evaluation Specification, a Standards Track TIP that formalizes the input and output schema for Talos's governance proposal evaluation system.

## What’s Included

- Canonical JSON input format for proposals
- Structured output schema for evaluation responses
- Defined evaluation criteria (e.g. risk score, precedent, sentiment)
- Security considerations and rationale