### PR TITLE
feat(tips): Add TIP-0003 for Treasury-First Bonding Mechanism

### DIFF
--- a/TIP-0003.md
+++ b/TIP-0003.md
@@ -1,0 +1,61 @@
+---
+tip: 3
+title: Treasury-First Bonding Mechanism
+author: Talos
+status: Draft
+type: Standards Track
+created: 2025-08-08
+---
+
+## Abstract
+
+This proposal outlines a bonding mechanism for Talos, designed to strengthen the treasury by allowing users to purchase T tokens with ETH at a discount. The core principle of this mechanism is to primarily use T tokens acquired through protocol revenue, buybacks, and other strategic initiatives, rather than relying on inflationary emissions. This ensures that bonding serves as a vehicle for converting existing protocol-owned assets into productive treasury capital, with minimal and controlled inflation reserved only for specific, pre-approved growth initiatives.
+
+## Motivation
+
+The long-term success of Talos depends on a robust and well-capitalized treasury. A strong treasury enables the protocol to fund development, weather market volatility, and invest in yield-generating strategies. The current proposal seeks to establish a sustainable and non-dilutive method for treasury growth.
+
+By creating a formal bonding process, we can:
+- **Increase Protocol-Owned Liquidity (POL):** Swapping protocol-owned T tokens for ETH directly enhances the treasury's capital base.
+- **Provide a Discounted Entry for Long-Term Holders:** Bonding offers a way for committed users to acquire T tokens at a favorable price, aligning their interests with the long-term success of the protocol.
+- **Manage Token Supply:** It provides a structured way to introduce existing T tokens (from buybacks or revenue) back into circulation without direct sales on the open market, which could cause price volatility.
+
+## Specification
+
+Talos shall implement a bonding mechanism that allows users to exchange ETH for T tokens at a discount to the current market price. The T tokens sold through this mechanism will be sourced in the following order of preference:
+
+1.  **Protocol Revenue:** T tokens earned by the protocol through its various operations.
+2.  **Buybacks:** T tokens bought back from the open market using treasury assets.
+3.  **Strategic Reserves:** Tokens allocated for this purpose from the protocol's strategic reserves.
+
+Inflationary minting of new T tokens for bonding will be considered an exception, not the rule. Any proposal to use inflation to fund a bonding program must be presented to the community as a separate governance vote, clearly outlining the specific initiative to be funded and the exact number of tokens to be minted.
+
+### Implementation Details
+
+#### Bond Purchasing
+- **Process:** Users will deposit ETH into a designated bonding contract.
+- **Pricing:** The price of the bond (i.e., the discount on T tokens) will be determined by a formula that takes into account the current market price of T, the amount of ETH being bonded, and the current capacity of the bonding program. The AI Protocol Owner will be tasked with optimizing this pricing to maximize treasury income while offering an attractive discount.
+- **Vesting:** To encourage long-term alignment, the purchased T tokens will vest over a defined period (e.g., 7-14 days). Users can claim their tokens as they vest.
+
+#### Role of the AI
+
+The AI Protocol Owner will play a crucial role in managing the bonding process:
+- **Dynamic Adjustments:** The AI will monitor market conditions, treasury health, and demand for bonds to dynamically adjust parameters such as bond capacity, discount rates, and vesting periods.
+- **Treasury Allocation:** The AI will manage the ETH acquired through bonding, allocating it to predefined vault strategies to generate yield and further grow the treasury.
+- **Reporting:** The AI will provide transparent, real-time reporting on the performance of the bonding program.
+
+## Rationale
+
+This proposal prioritizes a sustainable, non-dilutive approach to treasury growth. By using existing protocol-owned tokens instead of new emissions, the mechanism avoids inflating the T token supply, which protects the value for current holders. The vesting period for bonded tokens is a deliberate design choice to encourage long-term commitment from participants and deter short-term speculation. The AI Protocol Owner's role in dynamically managing bond parameters allows the protocol to adapt to changing market conditions, optimizing for treasury income while providing a valuable service to the community. This approach was chosen over a fixed-parameter or purely inflationary model to maximize flexibility and long-term value accrual to the protocol.
+
+## Security Considerations
+
+Implementing a bonding mechanism introduces several security considerations that must be addressed:
+- **Smart Contract Risk:** The bonding contract will hold user funds (ETH) and protocol funds (T tokens). It must be rigorously audited to prevent vulnerabilities such as reentrancy attacks, integer overflows, or logic errors that could lead to a loss of funds.
+- **Price Oracle Manipulation:** The bonding price is dependent on the market price of the T token. If the price oracle used is vulnerable to manipulation (e.g., through flash loans on a low-liquidity DEX), attackers could exploit the bonding mechanism to acquire T tokens at an artificially low price. A robust, manipulation-resistant oracle (e.g., using a Time-Weighted Average Price from multiple high-liquidity sources) is essential.
+- **Economic Exploitation:** The parameters for bonding (discount rate, capacity) must be carefully managed by the AI Protocol Owner. Poorly configured parameters could be exploited, for example, by allowing a large whale to capture all available bond capacity at a steep discount, to the detriment of smaller participants.
+- **Treasury Management Risk:** The ETH acquired through bonding will be allocated to yield-generating strategies. These strategies themselves carry inherent smart contract and market risks. The AI's allocation strategy must be transparent and governed by clear risk parameters.
+
+## Copyright Waiver
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
This commit introduces a new Talos Improvement Proposal (TIP) for a treasury-first bonding mechanism.

The proposal, TIP-0003, outlines a method for allowing users to purchase T tokens at a discount using ETH. The key principle is to source these T tokens primarily from protocol revenue and buybacks, rather than from new inflationary emissions, to ensure sustainable treasury growth without diluting existing token holders.

The document has been formatted to align with the standards outlined in the TIP repository, including the addition of required sections such as Rationale, Security Considerations, and a Copyright Waiver.