### PR TITLE
TIP-0011: TALOS Flywheel — Yield Buybacks, LP Staking & Treasury Growth

### DIFF
--- a/TIP-0011.md
+++ b/TIP-0011.md
@@ -1,0 +1,102 @@
+---
+tip: 11
+title: TALOS Flywheel — Yield Buybacks, LP Staking & Treasury Growth
+author: digitallawrence <lawrencedigitalco@gmail.com>
+status: Draft
+type: Standards Track
+created: 2025-08-24
+---
+
+## Abstract
+
+This proposal creates a sustainable value loop for Talos by (1) allocating 40% of net yield into recurring TALOS buybacks, (2) sunsetting single-sided staking in favor of LP staking, and (3) splitting buybacks between burns and treasury accumulation. The design turns protocol yield into both immediate token demand and long-term treasury growth, ensuring Talos' success directly strengthens TALOS itself.
+
+## Motivation
+
+Talos was built as a yield manager — aggregating, optimizing, and deploying capital into the highest-performing opportunities across DeFi [[1]](https://docs.talos.is/vault-strategies). Its goals are simple:
+
+1. Maximize yield for participants.
+2. Grow the protocol's treasury to secure long-term operations.
+3. Align TALOS token value with protocol adoption.
+
+Currently, single-sided staking ("Stag Hunt") [[3]](https://docs.talos.is/tokenomics/staking-the-stag-hunt) pays out rewards without contributing to liquidity or treasury growth, while protocol yield remains unlinked to token value. TIP-0011 closes this gap by ensuring Talos' core business (yield generation) feeds back into TALOS demand.
+
+The guiding principle: the best way to grow the treasury is to make TALOS — its largest asset — more valuable.
+
+## Specification
+
+### Yield Allocation
+
+- **Net Yield (NY)** = Revenue (R) – Operating Costs (OPEX)
+- **Buyback Pool (BP)** = 40% × NY
+
+This mirrors MakerDAO's "surplus buffer then buyback" discipline [[5]](https://research.artemis.xyz/p/maker-a-deep-dive-into-the-worlds)[[6]](https://docs.makerdao.com/keepers/the-auctions-of-the-maker-protocol)[[7]](https://tradedog.io/inside-makerdaos-token-buyback-strategy/).
+
+### Buyback Execution
+
+- Monthly, via TWAP on supported Arbitrum DEXs [[2]](https://docs.talos.is/tokenomics/talos-usdt).
+- 50% of purchased TALOS is burned (supply reduction).
+- 50% is transferred to the Treasury (asset accumulation, used for LP rewards and strategic reserves).
+- Buybacks gated by minimum liquidity and capped relative to historical trading volume [[8]](https://gov.gmx.io/t/gmx-transition-from-buyback-eth-and-distribute-eth-to-buyback-gmx-and-distribute-gmx/3693).
+
+### Staking Transition
+
+- Retire single-sided staking [[3]](https://docs.talos.is/tokenomics/staking-the-stag-hunt) (unproductive and inflationary).
+- Launch LP staking vaults (TALOS/ETH, TALOS/USDC) incentivized with treasury-held TALOS.
+- LP staking strengthened by **ve-style time-weighted boosts** (longer locks → higher rewards) [[9]](https://resources.curve.fi/crv-token/overview/)[[10]](https://resources.curve.fi/vecrv/overview/)[[11]](https://www.cube.exchange/what-is/vetokenomics).
+
+### Bonding & POL
+
+- Expand bonding: protocol accepts ETH or LP tokens at a discount with vesting, routing proceeds into protocol-owned liquidity (POL) [[12]](https://docs.talos.is/tokenomics/bonding).
+- Governance targets ≥33% of main LP positions owned by Treasury, following Frax's POL/AMO model [[13]](https://docs.frax.com/protocol)[[14]](https://iq.wiki/wiki/pol-protocol-owned-liquidity).
+
+### Example (Base Case)
+
+If annual revenue = $10M, OPEX = $4M → Net Yield = $6M:
+
+- Buyback Pool = $2.4M annually
+- At $2 per TALOS = 1.2M tokens purchased
+- 600k burned (deflationary pressure)  
+- 600k added to treasury (compounding reserves)
+
+## Rationale
+
+1. **Direct Token Accrual**: Protocol yield becomes token demand.
+2. **Treasury as Growth Engine**: Treasury compounds TALOS, ensuring balance sheet strength tracks token appreciation.
+3. **Liquidity Alignment**: LP staking deepens liquidity and reduces volatility, unlike single-sided staking.
+4. **Flywheel Effect**: More TVL → More yield → Larger buybacks → Higher TALOS value → Stronger treasury → Better incentives → More TVL.
+
+This combines MakerDAO's surplus buffer [[5]](https://research.artemis.xyz/p/maker-a-deep-dive-into-the-worlds), GMX's fee-to-buyback evolution [[8]](https://gov.gmx.io/t/gmx-transition-from-buyback-eth-and-distribute-eth-to-buyback-gmx-and-distribute-gmx/3693), Curve's ve-style staking [[9]](https://resources.curve.fi/crv-token/overview/)[[10]](https://resources.curve.fi/vecrv/overview/), and Frax's POL discipline [[13]](https://docs.frax.com/protocol).
+
+## Security Considerations
+
+### Price Manipulation Protection
+- **TWAP Implementation**: Buybacks use time-weighted average price to prevent flash loan manipulation.  
+- **Liquidity Thresholds**: Enforce minimum pool depth before execution.  
+- **Volume Caps**: Limit buybacks to ≤10% of 30-day DEX volume.
+
+### Smart Contract Security
+- **Emergency Controls**: Governance-controlled pause mechanisms.  
+- **Access Controls**: Role-based permissions for sensitive functions.  
+- **Upgrade Safety**: Upgradeable contracts behind timelocks.
+
+### Economic Risks
+- **Treasury Concentration**: TALOS-heavy treasury introduces correlation risk.  
+- **MEV Protection**: Buybacks routed through private mempools or commit-reveal schemes.  
+- **Migration Safety**: Guided wind-down of single-sided staking to LP staking vaults.
+
+## Implementation
+
+1. Deploy automated buyback + burn contract with 50/50 split.
+2. Decommission single-sided staking contracts [[3]](https://docs.talos.is/tokenomics/staking-the-stag-hunt).
+3. Launch LP staking vaults with ve-style boosts [[9]](https://resources.curve.fi/crv-token/overview/)[[10]](https://resources.curve.fi/vecrv/overview/).
+4. Activate bonding for POL expansion [[12]](https://docs.talos.is/tokenomics/bonding).
+5. Launch dashboard for real-time transparency: NY, buybacks, burns, treasury TALOS.
+
+## Conclusion
+
+TIP-0011 transforms Talos' tokenomics into a self-reinforcing growth engine: yield fuels buybacks, buybacks fuel TALOS demand, treasury grows in TALOS, and LP staking ensures deep liquidity. By aligning Talos' revenue with tokenholder value and making TALOS the treasury's appreciating core asset, the protocol secures both the short-term pump and the long-term sustainability that defines a successful yield manager.
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).


### PR DESCRIPTION
## Summary
Proposes a sustainable value loop for Talos by routing 40% of net yield into TALOS buybacks (50% burn/50% treasury), retiring single-sided staking for LP staking, and implementing ve-style boosts with POL expansion.

## Type
Standards Track - Protocol mechanism changes

## Key Changes
- Monthly TWAP buybacks from 40% of net yield
- Migration from "Stag Hunt" to LP staking vaults
- Treasury accumulates TALOS for compounding growth
- Bonding expansion targeting ≥33% POL

Closes gap between protocol yield generation and token value.